### PR TITLE
fix mantis bug #29165: Tests in lso not shown in testoverview

### DIFF
--- a/classes/class.ilTestOverviewTestSelectionExplorer.php
+++ b/classes/class.ilTestOverviewTestSelectionExplorer.php
@@ -21,6 +21,7 @@ class ilTestOverviewTestSelectionExplorer extends ilPasteIntoMultipleItemsExplor
 		$this->removeFormItemForType('grp');
 		$this->removeFormItemForType('cat');
 		$this->removeFormItemForType('fold');
+    $this->removeFormItemForType('lso');
 		$this->addFormItemForType('tst');
 		$this->addFilter('tst');
 	}


### PR DESCRIPTION
This fixes mantis bug #29165 together with a core commit. Tests inside lso are currently not shown in the testoverview picker since lsos are not shown.