### PR TITLE
Hide anonymous tests

### DIFF
--- a/classes/class.ilTestOverviewTestSelectionExplorer.php
+++ b/classes/class.ilTestOverviewTestSelectionExplorer.php
@@ -57,7 +57,8 @@ class ilTestOverviewTestSelectionExplorer extends ilPasteIntoMultipleItemsExplor
         $visible = parent::isVisible($a_ref_id, $a_type);
 
         if('tst' == $a_type) {
-            if(!$ilAccess->checkAccess('tst_statistics', '', (int)$a_ref_id) && !$ilAccess->checkAccess('write', '', $a_ref_id)) {
+            $test = ilObjectFactory::getInstanceByRefId($a_ref_id);
+            if((!$ilAccess->checkAccess('tst_statistics', '', (int)$a_ref_id) && !$ilAccess->checkAccess('write', '', $a_ref_id)) || $test->getAnonymity()) {
                 return false;
             }
         }


### PR DESCRIPTION
With this change, it is no longer possible to add anonymous tests by mistake.