### PR TITLE
Fix green highlighting in excel export

### DIFF
--- a/classes/class.ilTestOverviewExcelExporter.php
+++ b/classes/class.ilTestOverviewExcelExporter.php
@@ -104,7 +104,7 @@ class ilTestOverviewExcelExporter
                 $color = "999999";
             } elseif (str_replace('##red-result##', '', $value) !== $value) {
                 $color = "FF0000";
-            } elseif (str_replace('##green_result##', '', $value) !== $value) {
+            } elseif (str_replace('##green-result##', '', $value) !== $value) {
                 $color = "00CC00";
             } elseif (str_replace('##yellow-result##', '', $value) !== $value) {
                 $color = "FFC100";


### PR DESCRIPTION
The Excel export was highlighted in red and orange, but not coloured in green. It was a small typo ;)