### PR TITLE
Fix Excel-Export: no-results to columns and do not use temp_results

### DIFF
--- a/classes/GUI/class.ilTestOverviewTableGUI.php
+++ b/classes/GUI/class.ilTestOverviewTableGUI.php
@@ -263,6 +263,7 @@ class ilTestOverviewTableGUI extends ilMappedTableGUI
                 $this->tpl->setCurrentBlock('cell');
                 $this->tpl->parseCurrentBlock();
                 $row_data[] = "##no-result##";
+		$results[] = '##no-result##';
             } else {
                 $testResult = null;
                 global $ilUser;
@@ -317,12 +318,12 @@ class ilTestOverviewTableGUI extends ilMappedTableGUI
         $row_data[] = $user->getFirstname();
         $row_data[] = $user->getLastname();
         $row_data[] = $user->getLogin();
-        //foreach($results as $item) {
-        //    $row_data[] = $item;
-        //}
-        foreach($this->temp_results as $item) {
+        foreach($results as $item) {
             $row_data[] = $item;
         }
+        //foreach($this->temp_results as $item) {
+        //    $row_data[] = $item;
+        //}
         $this->export_row_data[] = $row_data;
         $this->temp_results = array();
 


### PR DESCRIPTION
1) Only a fraction of the values were filled in during the Excel export. This was because the $temp_results were used. (Although I didn't have the time to go that far to understand what this is). If you use the correct, commented out, $results, the values are correct.
2) Normal fix: The ##no-result## must also be included in the export, otherwise the columns will shift incorrectly.

Final note: Nothing is calculated in the Excel export. No total, no average. None of the things you can activate in the options for the GUI.